### PR TITLE
Update install_log_server.sh

### DIFF
--- a/puppet/install_log_server.sh
+++ b/puppet/install_log_server.sh
@@ -6,6 +6,12 @@ set -e
 
 THIS_DIR=`pwd`
 
+# TODO: Either edit the variables here and make sure the values are correct, or
+# set them before running this script
+: ${LOG_SERVER_DOMAIN:=csim.hp.com}
+# No whitespace (i.e. remove "ssh-rsa " identifier and ending comment field)!
+: ${JENKINS_SSH_PUBLIC_KEY_CONTENTS:="AAAAB3NzaC1yc2EAAAADAQABAAAAgQCZBfq9HkS9urOg2lRkv+9B3tKDLu9h3QRd43aoMXQLXmivurnGEeVf1mptpWGeMB6E89XC/+xsMM3MxAlTQAuaTEhQ0aZjYpdawToYaj92BvoQRNShvQOOTIeehcZwJzudXu1WLXlv1+0gJIwPswkVqfnn5ptXePh3qhb2jFaZUQ=="}
+
 OSEXT_PATH=$THIS_DIR/os-ext-testing
 OSEXT_REPO=https://github.com/rasselin/os-ext-testing
 PUPPET_MODULE_PATH="--modulepath=$OSEXT_PATH/puppet/modules:/root/system-config/modules:/etc/puppet/modules"
@@ -47,12 +53,6 @@ if [[ "$PULL_LATEST_OSEXT_REPO" == "1" ]]; then
     echo "Pulling latest os-ext-testing repo master..."
     cd $OSEXT_PATH; git checkout master && sudo git pull; cd $THIS_DIR
 fi
-
-#TODO: Change this to your own domain
-LOG_SERVER_DOMAIN=csim.hp.com
-
-# No whitespace!
-JENKINS_SSH_PUBLIC_KEY_CONTENTS="AAAAB3NzaC1yc2EAAAADAQABAAAAgQCZBfq9HkS9urOg2lRkv+9B3tKDLu9h3QRd43aoMXQLXmivurnGEeVf1mptpWGeMB6E89XC/+xsMM3MxAlTQAuaTEhQ0aZjYpdawToYaj92BvoQRNShvQOOTIeehcZwJzudXu1WLXlv1+0gJIwPswkVqfnn5ptXePh3qhb2jFaZUQ=="
 
 CLASS_ARGS="domain => '$LOG_SERVER_DOMAIN', "
 CLASS_ARGS="$CLASS_ARGS jenkins_ssh_key => '$JENKINS_SSH_PUBLIC_KEY_CONTENTS', "


### PR DESCRIPTION
Allow LOG_SERVER_DOMAIN and JENKINS_SSH_PUBLIC_KEY_CONTENTS to be set externally to the script to make it easier to automate